### PR TITLE
Include $product when creating filter 'bring_fraktguiden_standard_url_params' 

### DIFF
--- a/classes/class-wc-shipping-method-bring.php
+++ b/classes/class-wc-shipping-method-bring.php
@@ -556,7 +556,8 @@ class WC_Shipping_Method_Bring extends WC_Shipping_Method {
 				'postingatpostoffice' => ( 'no' === $this->post_office ) ? 'false' : 'true',
 				'additionalservice'   => $additional_service ?? '',
 				'language'            => $this->get_bring_language(),
-			]
+			],
+			$package
 		);
 	}
 


### PR DESCRIPTION
In order to successfully apply filter in multivendor marketplaces where the sender is not the Woocommerce defined address, it is necessary to send the package variable to the 'bring_fraktguiden_standard_url_params' filter. From the package it is easy to find the sender in e.g. Dokan Multivendor Marketplace.